### PR TITLE
Chain together path and time parameterization

### DIFF
--- a/traj/launch/sim_demo.launch
+++ b/traj/launch/sim_demo.launch
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<launch>
+
+  <!-- Load robot model -->
+  <include file="$(find fanuc_m20ib_support)/launch/load_m20ib25.launch" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+
+  <!-- industrial_robot_simulator: accepts robot commands and reports status -->
+  <rosparam param="controller_joint_names">['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']</rosparam>
+  <node pkg="industrial_robot_simulator" type="industrial_robot_simulator" name="industrial_robot_simulator"/>
+  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action"/>
+
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+
+</launch>

--- a/traj/launch/sim_demo.launch
+++ b/traj/launch/sim_demo.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0" ?>
 <launch>
+  <arg name="plot" default="false"/>
 
   <!-- Load robot model -->
   <include file="$(find fanuc_m20ib_support)/launch/load_m20ib25.launch" />
@@ -9,6 +10,10 @@
   <rosparam param="controller_joint_names">['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']</rosparam>
   <node pkg="industrial_robot_simulator" type="industrial_robot_simulator" name="industrial_robot_simulator"/>
   <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action"/>
+
+  <node pkg="traj" type="demo" name="traj_demo">
+    <param name="plot" value="$(arg plot)"/>
+  </node>
 
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
 

--- a/traj/scripts/demo
+++ b/traj/scripts/demo
@@ -8,80 +8,100 @@ from trajectory_msgs.msg import JointTrajectoryPoint
 from matplotlib import pyplot as plt
 import numpy as np
 import rospy
+from sensor_msgs.msg import JointState
 
 import traj
 
 
-def create_joint_trajectory_goal(piecewise_position_function, joint_names, sample_period=0.008):
+def create_joint_trajectory_goal(piecewise_position_function, piecewise_velocity_function,
+                                 piecewise_acceleration_function, joint_names, sample_period=0.008):
     # Non-zero start times won't make sense to the controller
     assert piecewise_position_function.boundaries[0] == 0.0
     goal = FollowJointTrajectoryGoal()
+    goal.trajectory.header.stamp = rospy.Time.now()
+    goal.trajectory.header.frame_id = 'base_link'
     goal.trajectory.joint_names = joint_names
 
     for t in np.arange(0.0, piecewise_position_function.boundaries[-1], sample_period):
         point = JointTrajectoryPoint()
         point.time_from_start = rospy.Duration(t)
         point.positions = list(piecewise_position_function(t))
+        # point.velocities = list(piecewise_velocity_function(t))
+        # point.accelerations = list(piecewise_acceleration_function(t))
         goal.trajectory.points.append(point)
     return goal
 
 
+def joint_state_callback(joint_state_msg):
+    global initial_joint_states
+    initial_joint_states = joint_state_msg.position
+
+
+initial_joint_states = None
+
 # Joint limits for a fictional 6DoF arm.
 
-max_velocities = np.array([
+max_velocities = np.deg2rad(np.array([
     150.0,
     150.0,
     200.0,
     300.0,
     300.0,
     600.0,
-])
+]))
 
-max_accelerations = np.array([
+max_accelerations = np.deg2rad(np.array([
     500.0,
     500.0,
     700.0,
     1100.0,
     1100.0,
     2500.0,
-])
+]))
 
-max_jerks = np.array([
+max_jerks = np.deg2rad(np.array([
     4500.0,
     4500.0,
     5000.0,
     8000.0,
     8000.0,
     16000.0,
-])
+]))
 
 joint_names = ['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']
-
-# 1.0 = "I got this". 0.2 = "Uhhh... I guess we'll try it and see what happens".
-confidence_factor = 1.0
-
-# Simple path
-path = np.array([(0.0, 0.0, 0.0, 0.0, 0.0, 0.0), (1.5, 1.0, 0.3, 0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-                 (-1.5, 1.0, 0.3, 0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)])
-
-(trajectory_position_function, trajectory_velocity_function, trajectory_acceleration_funciton,
- trajectory_jerk_function) = traj.trajectory_for_path(path, confidence_factor * max_velocities,
-                                                      confidence_factor * max_accelerations,
-                                                      confidence_factor * max_jerks)
-
-traj.plot.plot_trajectory(plt.figure(), trajectory_position_function, trajectory_velocity_function,
-                          trajectory_acceleration_funciton, trajectory_jerk_function)
 
 rospy.init_node('traj_demo')
 follow_trajectory_client = actionlib.SimpleActionClient('joint_trajectory_action', FollowJointTrajectoryAction)
 follow_trajectory_client.wait_for_server()
 rospy.loginfo('Connected to joint trajectory server')
 
-goal = create_joint_trajectory_goal(trajectory_position_function, joint_names, sample_period=0.008)
+plot_trajectory = rospy.get_param('~plot', False)
+
+joint_states_sub = rospy.Subscriber('joint_states', JointState, joint_state_callback)
+while not rospy.is_shutdown() and initial_joint_states is None:
+    rospy.sleep(0.1)
+rospy.loginfo('Received a joint state message')
+start_values = initial_joint_states
+
+# Simple path
+path = np.array([initial_joint_states, (1.5, 0.7, 0.3, 0.0, -0.3, 0.0), initial_joint_states,
+                 (-1.5, 0.7, 0.3, 0.0, -0.3, 0.0), initial_joint_states])
+
+(trajectory_position_function, trajectory_velocity_function, trajectory_acceleration_function,
+ trajectory_jerk_function) = traj.trajectory_for_path(path, max_velocities,
+                                                      max_accelerations,
+                                                      max_jerks)
+
+goal = create_joint_trajectory_goal(trajectory_position_function, trajectory_velocity_function,
+                                    trajectory_acceleration_function, joint_names, sample_period=0.008)
+
 follow_trajectory_client.send_goal(goal)
 follow_trajectory_client.wait_for_result()
 
-if 1:
+if plot_trajectory:
+    traj.plot.plot_trajectory(plt.figure(), trajectory_position_function, trajectory_velocity_function,
+                              trajectory_acceleration_function, trajectory_jerk_function)
+
     plt.figure()
     traj.plot.plot_2d_path(plt.gca(), trajectory_position_function, 100, label='trajectory points')
     # Plot the waypoints in the original path for comparison.

--- a/traj/scripts/demo
+++ b/traj/scripts/demo
@@ -2,28 +2,89 @@
 """
 Simple example that parametrizes a 2d joint-space path.
 """
+import actionlib
+from control_msgs.msg import FollowJointTrajectoryAction, FollowJointTrajectoryGoal
+from trajectory_msgs.msg import JointTrajectoryPoint
 from matplotlib import pyplot as plt
 import numpy as np
+import rospy
 
 import traj
 
-# Joint limits (assumed to be the same for all axes).
-max_velocities = np.array([0.3, 0.3])
-max_accelerations = np.array([0.5, 0.5])
-max_jerks = np.array([2.0, 2.0])
 
-# Test path
-path = np.array([(0.0, 0.0), (0.5, 0.6), (-1.5, 0.8), (-0.2, 0.4)])
+def create_joint_trajectory_goal(piecewise_position_function, joint_names, sample_period=0.008):
+    # Non-zero start times won't make sense to the controller
+    assert piecewise_position_function.boundaries[0] == 0.0
+    goal = FollowJointTrajectoryGoal()
+    goal.trajectory.joint_names = joint_names
+
+    for t in np.arange(0.0, piecewise_position_function.boundaries[-1], sample_period):
+        point = JointTrajectoryPoint()
+        point.time_from_start = rospy.Duration(t)
+        point.positions = list(piecewise_position_function(t))
+        goal.trajectory.points.append(point)
+    return goal
+
+
+# Joint limits for a fictional 6DoF arm.
+
+max_velocities = np.array([
+    150.0,
+    150.0,
+    200.0,
+    300.0,
+    300.0,
+    600.0,
+])
+
+max_accelerations = np.array([
+    500.0,
+    500.0,
+    700.0,
+    1100.0,
+    1100.0,
+    2500.0,
+])
+
+max_jerks = np.array([
+    4500.0,
+    4500.0,
+    5000.0,
+    8000.0,
+    8000.0,
+    16000.0,
+])
+
+joint_names = ['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']
+
+# 1.0 = "I got this". 0.2 = "Uhhh... I guess we'll try it and see what happens".
+confidence_factor = 1.0
+
+# Simple path
+path = np.array([(0.0, 0.0, 0.0, 0.0, 0.0, 0.0), (1.5, 1.0, 0.3, 0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                 (-1.5, 1.0, 0.3, 0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)])
 
 (trajectory_position_function, trajectory_velocity_function, trajectory_acceleration_funciton,
- trajectory_jerk_function) = traj.trajectory_for_path(path, max_velocities, max_accelerations, max_jerks)
+ trajectory_jerk_function) = traj.trajectory_for_path(path, confidence_factor * max_velocities,
+                                                      confidence_factor * max_accelerations,
+                                                      confidence_factor * max_jerks)
 
 traj.plot.plot_trajectory(plt.figure(), trajectory_position_function, trajectory_velocity_function,
                           trajectory_acceleration_funciton, trajectory_jerk_function)
 
-plt.figure()
-traj.plot.plot_2d_path(plt.gca(), trajectory_position_function, 1000, label='trajectory points')
-# Plot the waypoints in the original path for comparison.
-plt.plot([q[0] for q in path], [q[1] for q in path], 'bx', label='original waypoints')
+rospy.init_node('traj_demo')
+follow_trajectory_client = actionlib.SimpleActionClient('joint_trajectory_action', FollowJointTrajectoryAction)
+follow_trajectory_client.wait_for_server()
+rospy.loginfo('Connected to joint trajectory server')
 
-plt.show()
+goal = create_joint_trajectory_goal(trajectory_position_function, joint_names, sample_period=0.008)
+follow_trajectory_client.send_goal(goal)
+follow_trajectory_client.wait_for_result()
+
+if 1:
+    plt.figure()
+    traj.plot.plot_2d_path(plt.gca(), trajectory_position_function, 100, label='trajectory points')
+    # Plot the waypoints in the original path for comparison.
+    plt.plot([q[0] for q in path], [q[1] for q in path], 'bx', label='original waypoints')
+
+    plt.show()

--- a/traj/scripts/demo
+++ b/traj/scripts/demo
@@ -9,11 +9,11 @@ import traj
 
 # Joint limits (assumed to be the same for all axes).
 max_velocities = np.array([0.3, 0.3])
-max_accelerations = np.array([1.0, 1.0])
-max_jerks = np.array([10.0, 10.0])
+max_accelerations = np.array([0.5, 0.5])
+max_jerks = np.array([2.0, 2.0])
 
 # Test path
-path = np.array([(0.0, 0.0), (0.5, 0.6), (1.5, 0.8), (-0.2, 0.4)])
+path = np.array([(0.0, 0.0), (0.5, 0.6), (-1.5, 0.8), (-0.2, 0.4)])
 
 (trajectory_position_function, trajectory_velocity_function, trajectory_acceleration_funciton,
  trajectory_jerk_function) = traj.trajectory_for_path(path, max_velocities, max_accelerations, max_jerks)

--- a/traj/scripts/demo
+++ b/traj/scripts/demo
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+Simple example that parametrizes a 2d joint-space path.
+"""
+from matplotlib import pyplot as plt
+import numpy as np
+
+import traj
+
+# Joint limits (assumed to be the same for all axes).
+max_velocities = np.array([0.3, 0.3])
+max_accelerations = np.array([1.0, 1.0])
+max_jerks = np.array([10.0, 10.0])
+
+# Test path
+path = np.array([(0.0, 0.0), (0.5, 0.6), (1.5, 0.8), (-0.2, 0.4)])
+
+(trajectory_position_function, trajectory_velocity_function, trajectory_acceleration_funciton,
+ trajectory_jerk_function) = traj.trajectory_for_path(path, max_velocities, max_accelerations, max_jerks)
+
+traj.plot.plot_trajectory(plt.figure(), trajectory_position_function, trajectory_velocity_function,
+                          trajectory_acceleration_funciton, trajectory_jerk_function)
+
+plt.figure()
+traj.plot.plot_2d_path(plt.gca(), trajectory_position_function, 1000, label='trajectory points')
+# Plot the waypoints in the original path for comparison.
+plt.plot([q[0] for q in path], [q[1] for q in path], 'bx', label='original waypoints')
+
+plt.show()

--- a/traj/scripts/seven_segment_example
+++ b/traj/scripts/seven_segment_example
@@ -3,20 +3,38 @@
 Simple example that computes a seven segment motion profile a 1d motion with given start and
 end positions. Start and end velocity/acceleration/jerk are assumed to be zero.
 """
+import time
+
 from matplotlib import pyplot as plt
-import numpy as np
+from sympy import Symbol
 
 import traj
 
 j_max = 0.1
-a_max = 0.4
-v_max = 2.0
+a_max = 2.0
+v_max = 10.0
 p_start = 0.0
 p_end = 30.0
+v_start = 0.0
+v_end = 0.0
 
-position, velocity, acceleration, jerk = traj.fit_seven_segment(
-        p_start, p_end, v_max, a_max, j_max)
+t = Symbol('t')
+
+
+
+t_start = time.time()
+jerk = traj.seven_segment_type4.fit(p_start, p_end, v_start, v_end, v_max, a_max, j_max, t)
+print('Fit function in {} seconds'.format(time.time() - t_start))
+
+t_start = time.time()
+acceleration = jerk.integral(0.0)
+velocity = acceleration.integral(0.0)
+position = velocity.integral(p_start)
+print('Integrated function in {} seconds'.format(time.time() - t_start))
+
+t_start = time.time()
 traj.plot.plot_trajectory(plt.gcf(), position, velocity, acceleration, jerk, n_points=100,
-        v_max=v_max, a_max=a_max, j_max=j_max)
-plt.show()
+                          v_max=v_max, a_max=a_max, j_max=j_max)
 
+print('Plotted function in {} seconds'.format(time.time() - t_start))
+plt.show()

--- a/traj/scripts/seven_segment_example
+++ b/traj/scripts/seven_segment_example
@@ -10,7 +10,7 @@ from sympy import Symbol
 
 import traj
 
-j_max = 0.1
+j_max = 10.0
 a_max = 2.0
 v_max = 10.0
 p_start = 0.0
@@ -20,16 +20,14 @@ v_end = 0.0
 
 t = Symbol('t')
 
-
-
 t_start = time.time()
-jerk = traj.seven_segment_type4.fit(p_start, p_end, v_start, v_end, v_max, a_max, j_max, t)
+jerk = traj.seven_segment_type4.fit(p_start, p_end, v_start, v_end, v_max, a_max, j_max, t, 8)
 print('Fit function in {} seconds'.format(time.time() - t_start))
 
 t_start = time.time()
-acceleration = jerk.integral(0.0)
-velocity = acceleration.integral(0.0)
-position = velocity.integral(p_start)
+acceleration = jerk.integrate(0.0)
+velocity = acceleration.integrate(v_start)
+position = velocity.integrate(p_start)
 print('Integrated function in {} seconds'.format(time.time() - t_start))
 
 t_start = time.time()

--- a/traj/scripts/seven_segment_example
+++ b/traj/scripts/seven_segment_example
@@ -16,7 +16,7 @@ v_max = 10.0
 p_start = 0.0
 p_end = 30.0
 v_start = 0.0
-v_end = 0.0
+v_end = 1.5
 
 t = Symbol('t')
 

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,6 +1,7 @@
 from parameterize_path import parameterize_path
 from piecewise_function import PiecewiseFunction
-from seven_segment import fit_seven_segment
+import seven_segment_type3
+import seven_segment_type4
 import plot
 from trajectory import trajectory_for_path
 

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -2,4 +2,5 @@ from parameterize_path import parameterize_path
 from piecewise_function import PiecewiseFunction
 from seven_segment import fit_seven_segment
 import plot
+from trajectory import trajectory_for_path
 

--- a/traj/src/traj/piecewise_function.py
+++ b/traj/src/traj/piecewise_function.py
@@ -29,7 +29,7 @@ class PiecewiseFunction:
     def extend(self, other):
         # If the start of the other piecewise function isn't zero, there would be a gap in the middle of the
         # combined function that would have no defined values. We don't have any good way to handle that.
-        assert(other.boundaries[0] == 0.0)
+        assert (other.boundaries[0] == 0.0)
         self.boundaries = np.concatenate((self.boundaries[:-1], other.boundaries + self.boundaries[-1]))
         self.functions = np.concatenate((self.functions, other.functions))
 
@@ -39,7 +39,7 @@ class PiecewiseFunction:
         path_points = np.array([self(v) for v in independent_variable_values])
         return independent_variable_values, path_points
 
-    def integral(self, integration_constant):
+    def integrate(self, integration_constant):
         integrated_functions = [integration_constant + self.functions[0].integrate(self.independent_variable)]
         for function_i in range(1, len(self.functions)):
             start_value = integrated_functions[function_i - 1].subs(self.independent_variable,

--- a/traj/src/traj/piecewise_function.py
+++ b/traj/src/traj/piecewise_function.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class PiecewiseFunction:
     """
     A piecewise function of a single variable.
@@ -8,9 +9,10 @@ class PiecewiseFunction:
     one variable, we are able to compute integrals correctly (unlike sympy's builtin piecewise
     function).
     """
+
     def __init__(self, boundaries, functions, independent_variable):
-        self.boundaries = boundaries
-        self.functions = functions
+        self.boundaries = np.asarray(boundaries)
+        self.functions = np.asarray(functions)
         self.independent_variable = independent_variable
         assert len(boundaries) - 1 == len(functions)
 
@@ -24,9 +26,24 @@ class PiecewiseFunction:
         return np.array(self.functions[func_i].subs(
             self.independent_variable, value_relative)).astype(np.float64).flatten()
 
+    def extend(self, other):
+        # If the start of the other piecewise function isn't zero, there would be a gap in the middle of the
+        # combined function that would have no defined values. We don't have any good way to handle that.
+        assert(other.boundaries[0] == 0.0)
+        self.boundaries = np.concatenate((self.boundaries[:-1], other.boundaries + self.boundaries[-1]))
+        self.functions = np.concatenate((self.functions, other.functions))
+
     def sample(self, npoints):
         independent_variable_values = np.linspace(
-                self.boundaries[0], self.boundaries[-1], npoints)
+            self.boundaries[0], self.boundaries[-1], npoints)
         path_points = np.array([self(v) for v in independent_variable_values])
         return independent_variable_values, path_points
 
+    def integral(self, integration_constant):
+        integrated_functions = [integration_constant + self.functions[0].integrate(self.independent_variable)]
+        for function_i in range(1, len(self.functions)):
+            start_value = integrated_functions[function_i - 1].subs(self.independent_variable,
+                                                                    self.boundaries[function_i] - self.boundaries[
+                                                                        function_i - 1])
+            integrated_functions.append(start_value + self.functions[function_i].integrate(self.independent_variable))
+        return PiecewiseFunction(self.boundaries[:], integrated_functions, self.independent_variable)

--- a/traj/src/traj/piecewise_function.py
+++ b/traj/src/traj/piecewise_function.py
@@ -12,7 +12,7 @@ class PiecewiseFunction:
 
     def __init__(self, boundaries, functions, independent_variable):
         self.boundaries = np.asarray(boundaries)
-        self.functions = np.asarray(functions)
+        self.functions = functions
         self.independent_variable = independent_variable
         assert len(boundaries) - 1 == len(functions)
 

--- a/traj/src/traj/piecewise_function.py
+++ b/traj/src/traj/piecewise_function.py
@@ -1,5 +1,4 @@
 import numpy as np
-from sympy import Matrix, Piecewise, Symbol
 
 class PiecewiseFunction:
     """

--- a/traj/src/traj/plot.py
+++ b/traj/src/traj/plot.py
@@ -11,7 +11,8 @@ Uses the entire provided figure, adding subplots as needed.
 """
 def plot_trajectory(figure, position, velocity, acceleration, jerk, n_points=1000, j_max=None,
         a_max=None, v_max=None):
-    plot_times = np.linspace(position.boundaries[0], position.boundaries[-1], 1000)
+    boundaries = jerk.boundaries
+    plot_times = np.linspace(position.boundaries[0], position.boundaries[-1], 100)
     positions = np.array([position(t) for t in plot_times])
     velocities = np.array([velocity(t) for t in plot_times])
     accelerations = np.array([acceleration(t) for t in plot_times])
@@ -28,17 +29,22 @@ def plot_trajectory(figure, position, velocity, acceleration, jerk, n_points=100
         axes[3].plot(plot_times, jerks[:,joint_i], c=c)
         axes[3].set_ylabel('jerk')
 
+    axes[0].vlines(boundaries, positions.min(), positions.max(), color=(0.8, 0.8, 0.8))
+
     if v_max is not None:
         axes[1].plot(plot_times, [v_max] * len(plot_times), '--', color='red')
         axes[1].plot(plot_times, [-v_max] * len(plot_times), '--', color='red')
+        axes[1].vlines(boundaries, -v_max, v_max, color=(0.8, 0.8, 0.8))
 
     if a_max is not None:
         axes[2].plot(plot_times, [a_max] * len(plot_times), '--', color='red')
         axes[2].plot(plot_times, [-a_max] * len(plot_times), '--', color='red')
+        axes[2].vlines(boundaries, -a_max, a_max, color=(0.8, 0.8, 0.8))
 
     if j_max is not None:
         axes[3].plot(plot_times, [j_max] * len(plot_times), '--', color='red')
         axes[3].plot(plot_times, [-j_max] * len(plot_times), '--', color='red')
+        axes[3].vlines(boundaries, -j_max, j_max, color=(0.8, 0.8, 0.8))
     plt.legend()
 
 """

--- a/traj/src/traj/plot.py
+++ b/traj/src/traj/plot.py
@@ -1,6 +1,8 @@
 from matplotlib import pyplot as plt
 import numpy as np
 
+joint_colors = ['r', 'b', 'g']
+
 """
 Plot a 1 dimensional trajectory. Plots position, velocity, acceleration, and jerk versus time
 in separate subplots.
@@ -14,24 +16,30 @@ def plot_trajectory(figure, position, velocity, acceleration, jerk, n_points=100
     velocities = np.array([velocity(t) for t in plot_times])
     accelerations = np.array([acceleration(t) for t in plot_times])
     jerks = np.array([jerk(t) for t in plot_times])
-    axes = figure.subplots(4)
-    axes[0].plot(plot_times, positions)
-    axes[0].set_ylabel('position')
-    axes[1].plot(plot_times, velocities)
-    axes[1].set_ylabel('velocity')
+    axes = figure.subplots(4, sharex=True)
+    for joint_i in range(positions.shape[1]):
+        c = joint_colors[joint_i]
+        axes[0].plot(plot_times, positions[:,joint_i], c=c)
+        axes[0].set_ylabel('position')
+        axes[1].plot(plot_times, velocities[:,joint_i], c=c)
+        axes[1].set_ylabel('velocity')
+        axes[2].plot(plot_times, accelerations[:,joint_i], c=c)
+        axes[2].set_ylabel('acceleration')
+        axes[3].plot(plot_times, jerks[:,joint_i], c=c)
+        axes[3].set_ylabel('jerk')
+
     if v_max is not None:
         axes[1].plot(plot_times, [v_max] * len(plot_times), '--', color='red')
         axes[1].plot(plot_times, [-v_max] * len(plot_times), '--', color='red')
-    axes[2].plot(plot_times, accelerations)
-    axes[2].set_ylabel('acceleration')
+
     if a_max is not None:
         axes[2].plot(plot_times, [a_max] * len(plot_times), '--', color='red')
         axes[2].plot(plot_times, [-a_max] * len(plot_times), '--', color='red')
-    axes[3].plot(plot_times, jerks)
-    axes[3].set_ylabel('jerk')
+
     if j_max is not None:
         axes[3].plot(plot_times, [j_max] * len(plot_times), '--', color='red')
         axes[3].plot(plot_times, [-j_max] * len(plot_times), '--', color='red')
+    plt.legend()
 
 """
 Plot the positions for a 2 dimensional path on the provided matplotlib axes.

--- a/traj/src/traj/plot.py
+++ b/traj/src/traj/plot.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot as plt
 import numpy as np
 
-joint_colors = ['r', 'b', 'g']
+joint_colors = ['r', 'b', 'g', 'c', 'm', 'y', 'k', 'w']
 
 """
 Plot a 1 dimensional trajectory. Plots position, velocity, acceleration, and jerk versus time

--- a/traj/src/traj/plot.py
+++ b/traj/src/traj/plot.py
@@ -9,10 +9,10 @@ in separate subplots.
 
 Uses the entire provided figure, adding subplots as needed.
 """
-def plot_trajectory(figure, position, velocity, acceleration, jerk, n_points=1000, j_max=None,
+def plot_trajectory(figure, position, velocity, acceleration, jerk, n_points=300, j_max=None,
         a_max=None, v_max=None):
     boundaries = jerk.boundaries
-    plot_times = np.linspace(position.boundaries[0], position.boundaries[-1], 100)
+    plot_times = np.linspace(position.boundaries[0], position.boundaries[-1], n_points)
     positions = np.array([position(t) for t in plot_times])
     velocities = np.array([velocity(t) for t in plot_times])
     accelerations = np.array([acceleration(t) for t in plot_times])

--- a/traj/src/traj/seven_segment.py
+++ b/traj/src/traj/seven_segment.py
@@ -3,7 +3,7 @@ from sympy.core.numbers import Float
 
 from .piecewise_function import PiecewiseFunction
 
-def fit_seven_segment(p_start, p_end, v_max, a_max, j_max):
+def fit_seven_segment(p_start, p_end, v_max, a_max, j_max, independent_variable=Symbol('t')):
     """
     Find the optimal seven segment trajectory for zero start and end velocities, and the given
     start and end positions.
@@ -68,24 +68,23 @@ def fit_seven_segment(p_start, p_end, v_max, a_max, j_max):
     acceleration_functions = []
     velocity_functions = []
     position_functions = []
-    t = Symbol('t')
     # Integrate jerk starting from the start of the trajectory and going all the way through the end.
     for j0, T in segment_jerks_and_durations:
         times.append(times[-1] + T)
         j = Float(j0)
-        a = integrate(j, t) + a0
-        v = integrate(a, t) + v0
-        p = integrate(v, t) + p0
+        a = integrate(j, independent_variable) + a0
+        v = integrate(a, independent_variable) + v0
+        p = integrate(v, independent_variable) + p0
         jerk_functions.append(j)
         acceleration_functions.append(a)
         velocity_functions.append(v)
         position_functions.append(p)
-        a0 = a.subs({t: T})
-        v0 = v.subs({t: T})
-        p0 = p.subs({t: T})
-    position = PiecewiseFunction(times, position_functions, t)
-    velocity = PiecewiseFunction(times, velocity_functions, t)
-    acceleration = PiecewiseFunction(times, acceleration_functions, t)
-    jerk = PiecewiseFunction(times, jerk_functions, t)
+        a0 = a.subs({independent_variable: T})
+        v0 = v.subs({independent_variable: T})
+        p0 = p.subs({independent_variable: T})
+    position = PiecewiseFunction(times, position_functions, independent_variable)
+    velocity = PiecewiseFunction(times, velocity_functions, independent_variable)
+    acceleration = PiecewiseFunction(times, acceleration_functions, independent_variable)
+    jerk = PiecewiseFunction(times, jerk_functions, independent_variable)
     return position, velocity, acceleration, jerk
 

--- a/traj/src/traj/seven_segment_type3.py
+++ b/traj/src/traj/seven_segment_type3.py
@@ -3,7 +3,8 @@ from sympy.core.numbers import Float
 
 from .piecewise_function import PiecewiseFunction
 
-def fit_seven_segment(p_start, p_end, v_max, a_max, j_max, independent_variable=Symbol('t')):
+
+def fit(p_start, p_end, v_max, a_max, j_max, independent_variable=Symbol('t')):
     """
     Find the optimal seven segment trajectory for zero start and end velocities, and the given
     start and end positions.
@@ -14,9 +15,9 @@ def fit_seven_segment(p_start, p_end, v_max, a_max, j_max, independent_variable=
         control for service manipulator robot." Workshop on Physical Human-Robot Interaction in
         Anthropic Domains at IROS. 2006.
     """
-    assert(a_max > 0.0)
-    assert(j_max > 0.0)
-    assert(v_max > 0.0)
+    assert (a_max > 0.0)
+    assert (j_max > 0.0)
+    assert (v_max > 0.0)
 
     # Maximum amount of time we can spend at any of our limit conditions before we violate the
     # next higher limit condition.
@@ -30,15 +31,15 @@ def fit_seven_segment(p_start, p_end, v_max, a_max, j_max, independent_variable=
         # to the max velocity, and we adjust the max time spent in the max jerk limited
         # section to just reach the new max acceleration.
         T_amax = 0.0
-        T_jmax = (v_max / j_max)**0.5
+        T_jmax = (v_max / j_max) ** 0.5
         print(T_jmax, j_max)
         a_max = T_jmax * j_max
 
     # Compute the minimum distance that each case can travel. D_thr1 is the minimum distance for a
     # trajectory that hits both max acceleration and max velocity. D_thr2 is the minimum distance
     # for a trajectory that hits max acceleration but not max velocity.
-    D_thr1 = (a_max * v_max) / j_max + v_max**2 / a_max
-    D_thr2 = 2.0 * a_max**3 / j_max**2
+    D_thr1 = (a_max * v_max) / j_max + v_max ** 2 / a_max
+    D_thr2 = 2.0 * a_max ** 3 / j_max ** 2
 
     D = p_end - p_start
     if D >= D_thr1:
@@ -50,15 +51,15 @@ def fit_seven_segment(p_start, p_end, v_max, a_max, j_max, independent_variable=
         # We hit a_max but not v_max
         T_v = 0.0
         T_j = T_jmax
-        T_a = (a_max**2 / (4.0 * j_max) + D / a_max)**0.5 - 1.5 * a_max / j_max
+        T_a = (a_max ** 2 / (4.0 * j_max) + D / a_max) ** 0.5 - 1.5 * a_max / j_max
     else:
         # We hit neither a_max nor v_max
         T_v = 0.0
         T_a = 0.0
-        T_j = (D / (2.0 * j_max))**(1.0 / 3.0)
+        T_j = (D / (2.0 * j_max)) ** (1.0 / 3.0)
 
     segment_jerks_and_durations = [(j_max, T_j), (0.0, T_a), (-j_max, T_j), (0.0, T_v), (-j_max,
-        T_j), (0.0, T_a), (j_max, T_j)]
+                                                                                         T_j), (0.0, T_a), (j_max, T_j)]
     segments = []
     p0 = p_start
     v0 = 0.0
@@ -87,4 +88,3 @@ def fit_seven_segment(p_start, p_end, v_max, a_max, j_max, independent_variable=
     acceleration = PiecewiseFunction(times, acceleration_functions, independent_variable)
     jerk = PiecewiseFunction(times, jerk_functions, independent_variable)
     return position, velocity, acceleration, jerk
-

--- a/traj/src/traj/seven_segment_type3.py
+++ b/traj/src/traj/seven_segment_type3.py
@@ -1,10 +1,10 @@
-from sympy import integrate, Symbol
+from sympy import integrate
 from sympy.core.numbers import Float
 
 from .piecewise_function import PiecewiseFunction
 
 
-def fit(p_start, p_end, v_max, a_max, j_max, independent_variable=Symbol('t')):
+def fit(p_start, p_end, v_max, a_max, j_max, independent_variable):
     """
     Find the optimal seven segment trajectory for zero start and end velocities, and the given
     start and end positions.
@@ -72,19 +72,7 @@ def fit(p_start, p_end, v_max, a_max, j_max, independent_variable=Symbol('t')):
     # Integrate jerk starting from the start of the trajectory and going all the way through the end.
     for j0, T in segment_jerks_and_durations:
         times.append(times[-1] + T)
-        j = Float(j0)
-        a = integrate(j, independent_variable) + a0
-        v = integrate(a, independent_variable) + v0
-        p = integrate(v, independent_variable) + p0
-        jerk_functions.append(j)
-        acceleration_functions.append(a)
-        velocity_functions.append(v)
-        position_functions.append(p)
-        a0 = a.subs({independent_variable: T})
-        v0 = v.subs({independent_variable: T})
-        p0 = p.subs({independent_variable: T})
-    position = PiecewiseFunction(times, position_functions, independent_variable)
-    velocity = PiecewiseFunction(times, velocity_functions, independent_variable)
-    acceleration = PiecewiseFunction(times, acceleration_functions, independent_variable)
+        jerk_functions.append(Float(j0))
+
     jerk = PiecewiseFunction(times, jerk_functions, independent_variable)
-    return position, velocity, acceleration, jerk
+    return jerk

--- a/traj/src/traj/seven_segment_type4.py
+++ b/traj/src/traj/seven_segment_type4.py
@@ -123,7 +123,7 @@ def fit_acceleration_trapezoid(v_start, v_end, a_max, j_max, independent_variabl
         np.cumsum([0.0, ramp_duration, segment_2_duration, ramp_duration]), [Float(j), Float(0.0), Float(-j)],
         independent_variable)
 
-    if VALIDATION_ENABLED or True:
+    if VALIDATION_ENABLED:
         validate_acceleration_segments(0.0, v_start, v_end, a_max, j_max, piecewise_jerk_function)
     return piecewise_jerk_function
 
@@ -181,8 +181,8 @@ def fit_given_cruising_velocity(p_start, p_end, v_start, v_end, v_cruise, a_max,
     jerk.extend(jerk_for_last_three_segments)
 
     v_max = max(v_start, v_end, v_cruise)
-
-    validate(p_start, p_end, v_start, v_end, v_max, a_max, j_max, jerk, independent_variable)
+    if VALIDATION_ENABLED:
+        validate(p_start, p_end, v_start, v_end, v_max, a_max, j_max, jerk, independent_variable)
     return jerk
 
 

--- a/traj/src/traj/seven_segment_type4.py
+++ b/traj/src/traj/seven_segment_type4.py
@@ -1,0 +1,193 @@
+import numpy as np
+from sympy.core.numbers import Float
+
+from .piecewise_function import PiecewiseFunction
+
+
+class InvalidTrajectory(Exception):
+    pass
+
+
+def validate(p_start, p_end, v_start, v_end, v_max, a_max, j_max, piecewise_jerk_function, independent_variable):
+    piecewise_acceleration_function = piecewise_jerk_function.integral(0.0)
+    piecewise_velocity_function = piecewise_acceleration_function.integral(v_start)
+    piecewise_position_function = piecewise_velocity_function.integral(p_start)
+    boundaries = piecewise_jerk_function.boundaries
+
+    if boundaries[0] != 0.0:
+        raise InvalidTrajectory()
+
+    # Boundary array must be sorted.
+    if (boundaries[:-1] > boundaries[1:]).any():
+        raise InvalidTrajectory()
+
+    if not np.isclose(piecewise_velocity_function(boundaries[0]), v_start):
+        raise InvalidTrajectory()
+
+    if not np.isclose(piecewise_velocity_function(boundaries[-1]), v_end):
+        raise InvalidTrajectory()
+
+    if not np.isclose(piecewise_position_function(boundaries[0]), p_start):
+        raise InvalidTrajectory()
+
+    if not np.isclose(piecewise_position_function(boundaries[-1]), p_end):
+        raise InvalidTrajectory()
+
+    for independent_variable_value in boundaries:
+        jerk = piecewise_jerk_function(independent_variable_value)
+        acceleration = piecewise_acceleration_function(independent_variable_value)
+        velocity = piecewise_velocity_function(independent_variable_value)
+        position = piecewise_position_function(independent_variable_value)
+        if np.abs(jerk) - np.abs(j_max) > 1e-8:
+            raise InvalidTrajectory()
+        if (np.abs(acceleration) - np.abs(a_max)) > 1e-8:
+            raise InvalidTrajectory()
+        if (np.abs(velocity) - np.abs(v_max)) > 1e-8:
+            raise InvalidTrajectory()
+        #if (np.abs(position) - np.abs(p_end)) > 1e-8:
+        #    raise InvalidTrajectory()
+    return True
+
+
+def validate_three_segment(independent_variable_start, v_start, v_end, a_max, j_max, piecewise_jerk_function):
+    piecewise_acceleration_function = piecewise_jerk_function.integral(0.0)
+    piecewise_velocity_function = piecewise_acceleration_function.integral(v_start)
+    boundaries = piecewise_jerk_function.boundaries
+
+    if boundaries[0] != independent_variable_start:
+        raise InvalidTrajectory()
+
+    # Boundary array must be sorted.
+    if (boundaries[:-1] > boundaries[1:]).any():
+        raise InvalidTrajectory()
+
+    if not np.isclose(piecewise_velocity_function(boundaries[0]), v_start):
+        raise InvalidTrajectory()
+
+    if not np.isclose(piecewise_velocity_function(boundaries[-1]), v_end):
+        raise InvalidTrajectory()
+
+    for independent_variable_value in boundaries:
+        jerk = piecewise_jerk_function(independent_variable_value)
+        acceleration = piecewise_acceleration_function(independent_variable_value)
+        if np.abs(jerk) > j_max:
+            raise InvalidTrajectory()
+        if (np.abs(acceleration) - np.abs(a_max)) > 1e-8:
+            raise InvalidTrajectory()
+    return True
+
+
+def fit_three_segment_given_cruising_acceleration(independent_variable_start, v_start, v_end, a_cruise, j_max,
+                                                  independent_variable):
+    segment_1_jerk = np.sign(a_cruise) * j_max
+    segment_2_jerk = 0.0
+    segment_3_jerk = np.sign(-a_cruise) * j_max
+    if a_cruise == 0.0:
+        # We special case this "stay in one place" condition because we'd run into
+        # divide-by-zero problems if we tried to calculate out the durations of
+        # each segment.
+        if v_end - v_start == 0.0:
+            segment_1_duration = 0.0
+            segment_2_duration = 0.0
+            segment_3_duration = segment_1_duration
+        else:
+            return None
+    else:
+        segment_1_duration = a_cruise / segment_1_jerk
+        assert (segment_1_duration >= 0.0)
+        segment_3_duration = segment_1_duration
+        v_start_of_segment_2 = v_start + 0.5 * segment_1_jerk * segment_1_duration ** 2.0
+        v_end_of_segment_2 = v_end + 0.5 * segment_3_jerk * segment_3_duration ** 2.0
+        segment_2_duration = (v_end_of_segment_2 - v_start_of_segment_2) / a_cruise
+        if segment_2_duration < 0.0:
+            return None
+
+        if not np.isfinite(segment_1_duration) or not np.isfinite(segment_2_duration):
+            return None
+
+    boundaries = [independent_variable_start]
+    for duration in [segment_1_duration, segment_2_duration, segment_3_duration]:
+        boundaries.append(boundaries[-1] + duration)
+
+    jerk_functions = np.array([Float(segment_1_jerk), Float(segment_2_jerk), Float(segment_3_jerk)])
+    piecewise_jerk_function = PiecewiseFunction(boundaries, jerk_functions, independent_variable)
+
+    validate_three_segment(independent_variable_start, v_start, v_end, a_cruise, j_max, piecewise_jerk_function)
+    return piecewise_jerk_function
+
+
+def fit_three_segment(independent_variable_start, v_start, v_end, a_max, j_max, independent_variable,
+                      num_accelerations_to_try=16):
+    best_piecewise_jerk = None
+    candidate_cruise_accelerations = np.sign(v_end - v_start) * np.linspace(a_max / float(num_accelerations_to_try),
+                                                                            a_max, num_accelerations_to_try)
+    for a_cruise in candidate_cruise_accelerations:
+        piecewise_jerk = fit_three_segment_given_cruising_acceleration(independent_variable_start, v_start, v_end,
+                                                                       a_cruise, j_max,
+                                                                       independent_variable)
+        if piecewise_jerk is None:
+            # Higher cruising accelerations definitely aren't feasible, return the best trajectory we've found.
+            return best_piecewise_jerk
+        best_piecewise_jerk = piecewise_jerk
+    return best_piecewise_jerk
+
+def fit_given_cruising_velocity(p_start, p_end, v_start, v_end, v_cruise, a_max, j_max, independent_variable):
+    jerk_for_first_three_segments = fit_three_segment(0.0, v_start, v_cruise, a_max, j_max, independent_variable)
+    if jerk_for_first_three_segments is None:
+        return None
+
+    jerk_for_last_three_segments = fit_three_segment(0.0, v_cruise, v_end, a_max, j_max,
+                                                     independent_variable)
+    if jerk_for_last_three_segments is None:
+        return None
+
+    acceleration_for_first_three_segments = jerk_for_first_three_segments.integral(0.0)
+    velocity_for_first_three_segments = acceleration_for_first_three_segments.integral(v_start)
+    position_for_first_three_segments = velocity_for_first_three_segments.integral(p_start)
+    segments_123_distance_traveled = position_for_first_three_segments(
+        position_for_first_three_segments.boundaries[-1]) - position_for_first_three_segments(
+        position_for_first_three_segments.boundaries[0])
+
+    acceleration_for_last_three_segments = jerk_for_last_three_segments.integral(0.0)
+    velocity_for_last_three_segments = acceleration_for_last_three_segments.integral(v_cruise)
+    # We're not yet sure what the start position will be - it will depend on how long we maintain our cruising
+    # velocity. For now we set it to 0.0 just to figure out how far we move in the last three segements.
+    position_for_last_three_segments = velocity_for_last_three_segments.integral(0.0)
+    segments_567_distance_traveled = position_for_last_three_segments(
+        position_for_last_three_segments.boundaries[-1]) - position_for_last_three_segments(
+        position_for_last_three_segments.boundaries[0])
+
+    segment_4_distance = (p_end - p_start - segments_123_distance_traveled - segments_567_distance_traveled)
+    total_distance = segments_123_distance_traveled + segment_4_distance + segments_567_distance_traveled
+    if np.abs(total_distance - (p_end - p_start)) > 1e-8:
+        return None
+    segment_4_duration = segment_4_distance / v_cruise
+    if segment_4_duration < 0.0:
+        return None
+
+    jerk_for_segment_4 = PiecewiseFunction([0.0, segment_4_duration], [Float(0.0)], independent_variable)
+
+    jerk = jerk_for_first_three_segments
+    jerk.extend(jerk_for_segment_4)
+    jerk.extend(jerk_for_last_three_segments)
+
+    v_max = max(v_start, v_end, v_cruise)
+
+    validate(p_start, p_end, v_start, v_end, v_max, a_max, j_max, jerk, independent_variable)
+    return jerk
+
+
+def fit(p_start, p_end, v_start, v_end, v_max, a_max, j_max, independent_variable,
+        num_velocities_to_try=16):
+    best_jerk = None
+    best_end_time = np.inf
+    for v_cruise in np.linspace(-v_max, v_max, num_velocities_to_try):
+        jerk = fit_given_cruising_velocity(p_start, p_end, v_start, v_end, v_cruise, a_max, j_max, independent_variable)
+        if jerk is None:
+            continue
+
+        end_time = jerk.boundaries[-1]
+        if end_time < best_end_time:
+            best_end_time = end_time
+            best_jerk = jerk
+    return best_jerk

--- a/traj/src/traj/trajectory.py
+++ b/traj/src/traj/trajectory.py
@@ -1,0 +1,58 @@
+import numpy as np
+from sympy import diff, Symbol
+
+from piecewise_function import PiecewiseFunction
+from parameterize_path import parameterize_path
+from seven_segment import fit_seven_segment
+
+def project_limits_onto_s(limits, function):
+    slope = np.abs(np.array(diff(function)).astype(np.float64).flatten())
+    limit_factor = limits / slope
+
+    return min(limit_factor)
+
+def trajectory_for_path(path, max_velocities, max_accelerations, max_jerks):
+    path_function = parameterize_path(path)
+    t = Symbol('t')
+    s = path_function.independent_variable
+    trajectory_position_functions = []
+    trajectory_velocity_functions = []
+    trajectory_acceleration_functions = []
+    trajectory_jerk_functions = []
+    trajectory_boundaries = [0.0]
+    for segment_i in range(len(path_function.functions)):
+        fsegment = path_function.functions[segment_i]
+
+        s0 = path_function.boundaries[segment_i]
+        s1 = path_function.boundaries[segment_i + 1]
+
+        p_start = np.array(fsegment.subs(s, 0.0)).astype(np.float64).flatten()
+        p_end = np.array(fsegment.subs(s, s1 - s0)).astype(np.float64).flatten()
+        print(p_start, p_end)
+
+        # Project joint limits onto this segment's direction to get limits on s
+        v_max = project_limits_onto_s(max_velocities, fsegment)
+        a_max = project_limits_onto_s(max_accelerations, fsegment)
+        j_max = project_limits_onto_s(max_jerks, fsegment)
+
+        # Compute 7 segment profile for s as a function of time.
+        this_segment_start_time = trajectory_boundaries[-1]
+        s_position, s_velocity, s_acceleration, s_jerk = fit_seven_segment(0, s1-s0, v_max, a_max, j_max, t)
+
+        # Substitute time profile for s into the path function to get trajectory as a function of t.
+        for function_i in range(len(s_position.functions)):
+            position_vs_t = fsegment.subs(s, s_position.functions[function_i])
+            velocity_vs_t = diff(position_vs_t)
+            acceleration_vs_t = diff(velocity_vs_t)
+            jerk_vs_t = diff(acceleration_vs_t)
+            trajectory_position_functions.append(position_vs_t)
+            trajectory_velocity_functions.append(velocity_vs_t)
+            trajectory_acceleration_functions.append(acceleration_vs_t)
+            trajectory_jerk_functions.append(jerk_vs_t)
+            trajectory_boundaries.append(s_position.boundaries[function_i + 1] + this_segment_start_time)
+
+    return (PiecewiseFunction(trajectory_boundaries, trajectory_position_functions, t),
+            PiecewiseFunction(trajectory_boundaries, trajectory_velocity_functions, t),
+            PiecewiseFunction(trajectory_boundaries, trajectory_acceleration_functions, t),
+            PiecewiseFunction(trajectory_boundaries, trajectory_jerk_functions, t))
+

--- a/traj/test/test_seven_segment_type3.py
+++ b/traj/test/test_seven_segment_type3.py
@@ -1,11 +1,15 @@
 import numpy as np
+from sympy import integrate, Symbol
 
 import traj
 
 
 def check_fit_seven_segment(p_start, p_end, v_max, a_max, j_max):
-    position, velocity, jerk, acceleration = traj.seven_segment_type3.fit(
-        p_start, p_end, v_max, a_max, j_max)
+    t = Symbol('t')
+    jerk = traj.seven_segment_type3.fit(p_start, p_end, v_max, a_max, j_max, t)
+    acceleration = jerk.integrate(0.0)
+    velocity = acceleration.integrate(0.0)
+    position = velocity.integrate(p_start)
 
     t_start = position.boundaries[0]
     t_end = position.boundaries[-1]

--- a/traj/test/test_seven_segment_type3.py
+++ b/traj/test/test_seven_segment_type3.py
@@ -1,11 +1,11 @@
-import nose
 import numpy as np
 
-from traj import fit_seven_segment
+import traj
+
 
 def check_fit_seven_segment(p_start, p_end, v_max, a_max, j_max):
-    position, velocity, jerk, acceleration = fit_seven_segment(
-            p_start, p_end, v_max, a_max, j_max)
+    position, velocity, jerk, acceleration = traj.seven_segment_type3.fit(
+        p_start, p_end, v_max, a_max, j_max)
 
     t_start = position.boundaries[0]
     t_end = position.boundaries[-1]
@@ -17,15 +17,18 @@ def check_fit_seven_segment(p_start, p_end, v_max, a_max, j_max):
     assert np.isclose(p_start, p_start_computed)
     assert np.isclose(p_end, p_end_computed)
 
+
 def test_max_vel_but_not_max_acc():
     check_fit_seven_segment(0.0, 30.0, 0.1, 3.0, 0.1)
+
 
 def test_max_acc_but_not_max_vel():
     check_fit_seven_segment(0.0, 30.0, 6.0, 3.0, 0.1)
 
+
 def test_not_max_vel_or__max_acc():
     check_fit_seven_segment(0.0, 0.4, 3.1, 2.3, 0.1)
 
+
 def test_max_vel_and_max_acc():
     check_fit_seven_segment(0.0, 30.0, 2.0, 0.4, 0.1)
-

--- a/traj/test/test_seven_segment_type4.py
+++ b/traj/test/test_seven_segment_type4.py
@@ -4,12 +4,14 @@ from sympy import Symbol
 
 import traj
 
+traj.VALIDATION_ENABLED = True
 
-def check_fit_three_segment(independent_variable_start, v_start, v_end, a_max, j_max):
+
+def check_fit_acceleration_segments(v_start, v_end, a_max, j_max):
     t = Symbol('t')
-    jerk = traj.seven_segment_type4.fit_three_segment(independent_variable_start, v_start, v_end, a_max, j_max, t, 8)
-    acceleration = jerk.integral(0.0)
-    velocity = acceleration.integral(0.0)
+    jerk = traj.seven_segment_type4.fit_acceleration_segments(v_start, v_end, a_max, j_max, t)
+    acceleration = jerk.integrate(0.0)
+    velocity = acceleration.integrate(v_start)
 
     t_start = velocity.boundaries[0]
     t_end = velocity.boundaries[-1]
@@ -18,44 +20,52 @@ def check_fit_three_segment(independent_variable_start, v_start, v_end, a_max, j
 
     assert np.isclose(v_start, v_start_computed)
     assert np.isclose(v_end, v_end_computed)
+    return jerk, acceleration, velocity
 
 
-def check_fit_three_segment_given_cruising_acceleration(independent_variable_start, v_start, v_end, a_cruise, j_max):
+def check_fit(p_start, p_end, v_start, v_end, v_max, a_max, j_max):
     t = Symbol('t')
-    jerk = traj.seven_segment_type4.fit_three_segment_given_cruising_acceleration(independent_variable_start, v_start,
-                                                                                  v_end, a_cruise, j_max,
-                                                                                  t)
-    acceleration = jerk.integral(0.0)
-    velocity = acceleration.integral(v_start)
+    jerk = traj.seven_segment_type4.fit(p_start, p_end, v_start, v_end, v_max, a_max, j_max, t)
+    acceleration = jerk.integrate(0.0)
+    velocity = acceleration.integrate(v_start)
+    position = velocity.integrate(p_start)
 
     t_start = velocity.boundaries[0]
     t_end = velocity.boundaries[-1]
     v_start_computed = velocity(t_start)
+    p_start_computed = velocity(0.0)
     v_end_computed = velocity(t_end)
+    p_end_computed = position(t_end)
 
     assert np.isclose(v_start, v_start_computed)
+    assert np.isclose(p_start, p_start_computed)
     assert np.isclose(v_end, v_end_computed)
+    assert np.isclose(p_end, p_end_computed)
+    return jerk, acceleration, velocity, position
 
 
-def test_three_segment_given_cruising_acceleration():
+def test_fit_acceleration_segments():
     t = Symbol('t')
-    # Postive acceleration, positive change in vleocity; relatively simple case.
-    check_fit_three_segment_given_cruising_acceleration(0.0, 0.0, 1.0, 1.0, 10.0)
 
-    # Keep the same velocity - all segments should have zero length.
-    check_fit_three_segment_given_cruising_acceleration(0.0, 0.0, 0.0, 0.0, 10.0)
+    # Positive change in velocity; relatively simple case.
+    check_fit_acceleration_segments(0.0, 1.0, 1.0, 10.0)
 
-    # Can't achieve positive change in velocity using negative acceleration.
-    assert traj.seven_segment_type4.fit_three_segment_given_cruising_acceleration(
-        0.0, 0.0, -1.0, 1.0, 10.0, t) is None
+    # Non-zero starting velocity.
+    check_fit_acceleration_segments(-0.67, 1.6, 1.0, 10.0)
+
+    # Negative change in velocity.
+    check_fit_acceleration_segments(0.0, -1.0, 1.0, 10.0)
+
+    # Not enough time to reach max acceleration, so this should return an acceleration triangle with two segments.
+    jerk, _, _ = check_fit_acceleration_segments(0.0, 1.0, 1e6, 10.0)
+    assert len(jerk.functions) == 2
+
+    # Keep the same velocity - should return one zero length segment.
+    jerk, _, _ = check_fit_acceleration_segments(0.0, 0.0, 0.0, 10.0)
+    assert len(jerk.functions) == 1
 
 
 def test_seven_segment_given_cruising_acceleration():
     t = Symbol('t')
-    j_max = 0.1
 
-    jerk = traj.seven_segment_type4.fit_given_cruising_velocity(0.0, 30.0, 0.0, 0.0, 5.0, 2.0, 0.1, t)
-    assert jerk is not None
-
-
-nose.main()
+    check_fit(0.0, 30.0, 0.0, 0.0, 3.0, 2.0, 10.0)

--- a/traj/test/test_seven_segment_type4.py
+++ b/traj/test/test_seven_segment_type4.py
@@ -1,0 +1,61 @@
+import nose
+import numpy as np
+from sympy import Symbol
+
+import traj
+
+
+def check_fit_three_segment(independent_variable_start, v_start, v_end, a_max, j_max):
+    t = Symbol('t')
+    jerk = traj.seven_segment_type4.fit_three_segment(independent_variable_start, v_start, v_end, a_max, j_max, t, 8)
+    acceleration = jerk.integral(0.0)
+    velocity = acceleration.integral(0.0)
+
+    t_start = velocity.boundaries[0]
+    t_end = velocity.boundaries[-1]
+    v_start_computed = velocity(t_start)
+    v_end_computed = velocity(t_end)
+
+    assert np.isclose(v_start, v_start_computed)
+    assert np.isclose(v_end, v_end_computed)
+
+
+def check_fit_three_segment_given_cruising_acceleration(independent_variable_start, v_start, v_end, a_cruise, j_max):
+    t = Symbol('t')
+    jerk = traj.seven_segment_type4.fit_three_segment_given_cruising_acceleration(independent_variable_start, v_start,
+                                                                                  v_end, a_cruise, j_max,
+                                                                                  t)
+    acceleration = jerk.integral(0.0)
+    velocity = acceleration.integral(v_start)
+
+    t_start = velocity.boundaries[0]
+    t_end = velocity.boundaries[-1]
+    v_start_computed = velocity(t_start)
+    v_end_computed = velocity(t_end)
+
+    assert np.isclose(v_start, v_start_computed)
+    assert np.isclose(v_end, v_end_computed)
+
+
+def test_three_segment_given_cruising_acceleration():
+    t = Symbol('t')
+    # Postive acceleration, positive change in vleocity; relatively simple case.
+    check_fit_three_segment_given_cruising_acceleration(0.0, 0.0, 1.0, 1.0, 10.0)
+
+    # Keep the same velocity - all segments should have zero length.
+    check_fit_three_segment_given_cruising_acceleration(0.0, 0.0, 0.0, 0.0, 10.0)
+
+    # Can't achieve positive change in velocity using negative acceleration.
+    assert traj.seven_segment_type4.fit_three_segment_given_cruising_acceleration(
+        0.0, 0.0, -1.0, 1.0, 10.0, t) is None
+
+
+def test_seven_segment_given_cruising_acceleration():
+    t = Symbol('t')
+    j_max = 0.1
+
+    jerk = traj.seven_segment_type4.fit_given_cruising_velocity(0.0, 30.0, 0.0, 0.0, 5.0, 2.0, 0.1, t)
+    assert jerk is not None
+
+
+nose.main()


### PR DESCRIPTION
This PR adds a function, `trajectory_for_path()`, which takes a path as a sequence of points in joint space (representing a piecewise linear path in joint space) and returns continuous piecewise polynomial functions for joint positions, velocities, acclerations and jerks w.r.t. time that respect the provided velocity/acceleration/jerk limits while following the path in the minimum time.

Caveat: the trajectory has zero velocity and acceleration at each waypoint, and is only "optimal" within that constraint.

Here is the output of the example script called `demo` which finds a time parametrization for a 2-joint case with 4 waypoints. (waypoints in blue) and evenly spaced points in the time parametrization chosen (in red):

![path](https://user-images.githubusercontent.com/1538056/71951453-f2188900-318f-11ea-8495-fd3d3e7aca52.png)

Here are the joint positions, velocities, accelerations, and jerks vs. time. Joint 1 is in red and joint 2 is in blue.

![trajectory](https://user-images.githubusercontent.com/1538056/71951473-05c3ef80-3190-11ea-881d-f475984bd0be.png)

Next steps:
- harden this code. It needs more unit tests to make sure there aren't any major corner cases.
- add a simple ROS node that sends some time-optimal trajectories to our fanuc arm using the driver's FollowJointTrajectory action
- geometrically smooth the interface between path segments using pilz's polynomial blending approach
- allow non zero velocities at waypoints in the paths (@mahmoud-a-ali I could use your help with this part)
- put everything together

@bhomberg @gavanderhoorn  @mahmoud-a-ali @wongkaiweng @sosentos 
