### PR TITLE
Polynomial path segment blending

### DIFF
--- a/traj/scripts/parameterize_path_example
+++ b/traj/scripts/parameterize_path_example
@@ -3,6 +3,8 @@
 Simple example that parametrizes a 2d joint-space path.
 """
 from matplotlib import pyplot as plt
+import matplotlib.patches
+import matplotlib.collections
 import numpy as np
 
 import traj
@@ -10,14 +12,23 @@ import traj
 # Test path
 path = np.array([(0.0, 0.0), (1.0, 1.0), (1.5, 0.8), (-0.2, 0.4)])
 
+blend_radius = 0.2
+
 path_function = traj.parameterize_path(path)
 
-# Plot sampled points along the parametrized path.
-traj.plot.plot_2d_path(plt.gca(), path_function, 100)
+blended_path_function = traj.blend_parameterized_path(path_function, blend_radius)
+
+# Plot sampled points along the parameterized path.
+traj.plot.plot_2d_path(plt.gca(), blended_path_function, 100)
 
 # Plot the waypoints in the original path for comparison.
 plt.plot([q[0] for q in path], [q[1] for q in path], 'bx', label='original waypoints')
 
+# Plot the blend radii as circles around each waypoint.
+blend_patches = matplotlib.collections.PatchCollection(
+    [matplotlib.patches.Circle((q[0], q[1]), blend_radius) for q in path])
+plt.gca().add_collection(blend_patches)
+
+plt.gca().set_aspect('equal')
 plt.legend()
 plt.show()
-

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,4 +1,4 @@
-from parameterize_path import parameterize_path
+from parameterize_path import parameterize_path, blend_parameterized_path
 from piecewise_function import PiecewiseFunction
 import seven_segment_type3
 import seven_segment_type4

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,4 +1,5 @@
-from .parameterize_path import parameterize_path, blend_parameterized_path
+from .parameterize_path import (parameterize_path, blend_parameterized_path, blend_ratio, corrected_blend_ratio,
+                                create_blended_segment)
 from piecewise_function import PiecewiseFunction
 import seven_segment_type3
 import seven_segment_type4

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,4 +1,4 @@
-from parameterize_path import parameterize_path, blend_parameterized_path
+from .parameterize_path import parameterize_path, blend_parameterized_path
 from piecewise_function import PiecewiseFunction
 import seven_segment_type3
 import seven_segment_type4

--- a/traj/src/traj/plot.py
+++ b/traj/src/traj/plot.py
@@ -53,12 +53,12 @@ def plot_trajectory(figure, position, velocity, acceleration, jerk, n_points=300
 """
 Plot the positions for a 2 dimensional path on the provided matplotlib axes.
 """
-def plot_2d_path(axes, piecewise_function, npoints, label='path points'):
+def plot_2d_path(axes, piecewise_function, npoints, linewidth=1.0, label='path points'):
     """
     Plot a 2d path that is represented as a piecewise function of a single variable.
     """
     S, path_points = piecewise_function.sample(npoints)
-    axes.plot(path_points[:,0], path_points[:,1], 'r.-', label=label)
+    axes.plot(path_points[:,0], path_points[:,1], 'r.-', linewidth=linewidth, label=label)
     axes.set_title('Joint space path')
     axes.set_xlabel('Joint 1')
     axes.set_ylabel('Joint 2')

--- a/traj/test/test_parameterize_path.py
+++ b/traj/test/test_parameterize_path.py
@@ -1,0 +1,23 @@
+import nose
+import numpy as np
+from sympy import diff, Symbol
+
+import traj
+
+
+def test_blend_function():
+    s = Symbol('s')
+    # To create a blend that connects to both the previous and next segment, the value must be 0.0 for s=0.0,
+    # 1.0 for s=1.0. For the connection between the blended portion and the neighboring segments to be smooth, the
+    # derivative of the blend ratio must be 0 at both ends.
+    blend_ratio_function = traj.blend_ratio(s)
+    assert blend_ratio_function.subs(s, 0.0) == 0.0
+    assert diff(blend_ratio_function, s).subs(s, 0.0) == 0.0
+    assert blend_ratio_function.subs(s, 1.0) == 1.0
+    assert diff(blend_ratio_function, s).subs(s, 1.0) == 0.0
+
+def test_corrected_blend_function():
+    s = Symbol('s')
+    corrected_blend_ratio_function = traj.corrected_blend_ratio(s, 0.0, 10.9)
+    assert np.isclose(float(corrected_blend_ratio_function.subs(s, 0.0)), 0.0, 1e-7)
+    assert np.isclose(float(corrected_blend_ratio_function.subs(s, 10.9)), 1.0, 1e-7)


### PR DESCRIPTION
This is an attempt to use the approach from https://github.com/PilzDE/pilz_industrial_motion/blob/melodic-devel/pilz_trajectory_generation/doc/MotionBlendAlgorithmDescription.pdf to blend segments in a joint-space path. I ran into problems because the authors of that paper were blending trajectories, not paths. I had to take some liberties to make it work with paths that had no time parameterization, and the results are OK, but not quite what I think we want. Here's an example path after smoothing. The blend radii are drawn as circles.

![blended_path](https://user-images.githubusercontent.com/1538056/74302724-563ce880-4d0c-11ea-8904-d854bdb35d6b.png)

Note that path still goes exactly through the waypoints - this means that it has quite high curvature for very sharp turns (like the waypoint on the top right). I think I'd prefer it to shortcut and not hit the waypoint perfectly.

There is a parameter in the paper called T_s which I'm not yet sure how to set. It may be that with the right T_s, this will work better.

I'm planning on implementing a constant-curvature arc based blending next - it has the advantage of being much lower curvature, but the disadvantage of introducing `sin()` and `cos()` components, which will be more complex to reason about then pure polynomials. I think that is OK, since sin and cos are still easy to derivate and evaluate.

/cc @mahmoud-a-ali @gavanderhoorn @bhomberg 
