### PR TITLE
Arc based path blending

### DIFF
--- a/traj/scripts/parameterize_path_example
+++ b/traj/scripts/parameterize_path_example
@@ -2,17 +2,38 @@
 """
 Simple example that parametrizes a 2d joint-space path.
 """
+import argparse
+
 from matplotlib import pyplot as plt
+import matplotlib.patches
+import matplotlib.collections
 import numpy as np
 import traj
 
 # Test path
 path = np.array([(0.0, 0.0), (1.0, 1.0), (1.5, 0.8), (-0.2, 0.4)])
+
+parser = argparse.ArgumentParser(description='Parameterize a geometric path.')
+parser.add_argument('--blend-radius', default=0.2,
+                    help='radius of blend arcs between segments (zero for no blending)')
+args = parser.parse_args()
+
 path_function = traj.parameterize_path(path)
-# Plot sampled points along the parametrized path.
+if args.blend_radius > 0.0:
+    path_function = traj.blend_parameterized_path(path_function, args.blend_radius)
+
+# Plot sampled points along the parameterized path.
 traj.plot.plot_2d_path(plt.gca(), path_function, 100)
+
 # Plot the waypoints in the original path for comparison.
 plt.plot([q[0] for q in path], [q[1] for q in path], 'bx', label='original waypoints')
+
+# Plot the blend radii as circles around each waypoint.
+blend_patches = matplotlib.collections.PatchCollection(
+    [matplotlib.patches.Circle((q[0], q[1]), args.blend_radius) for q in path])
+plt.gca().add_collection(blend_patches)
+
+plt.gca().set_aspect('equal')
+
 plt.legend()
 plt.show()
-

--- a/traj/scripts/parameterize_path_example
+++ b/traj/scripts/parameterize_path_example
@@ -11,16 +11,17 @@ import numpy as np
 import traj
 
 # Test path
-path = np.array([(0.0, 0.0), (1.0, 1.0), (1.5, 0.8), (-0.2, 0.4)])
+path = np.array([(0.0, 0.0), (0.3, -0.7), (1.0, 1.0), (-0.2, 0.4)])
 
 parser = argparse.ArgumentParser(description='Parameterize a geometric path.')
-parser.add_argument('--blend-radius', default=0.2,
+parser.add_argument('--blend-radius', default=0.2, type=float,
                     help='radius of blend arcs between segments (zero for no blending)')
 args = parser.parse_args()
 
-path_function = traj.parameterize_path(path)
 if args.blend_radius > 0.0:
-    path_function = traj.blend_parameterized_path(path_function, args.blend_radius)
+    path_function = traj.parameterize_path_with_blends(path, args.blend_radius)
+else:
+    path_function = traj.parameterize_path(path)
 
 # Plot sampled points along the parameterized path.
 traj.plot.plot_2d_path(plt.gca(), path_function, 100)
@@ -28,10 +29,16 @@ traj.plot.plot_2d_path(plt.gca(), path_function, 100)
 # Plot the waypoints in the original path for comparison.
 plt.plot([q[0] for q in path], [q[1] for q in path], 'bx', label='original waypoints')
 
-# Plot the blend radii as circles around each waypoint.
-blend_patches = matplotlib.collections.PatchCollection(
-    [matplotlib.patches.Circle((q[0], q[1]), args.blend_radius) for q in path])
-plt.gca().add_collection(blend_patches)
+if args.blend_radius > 0.0:
+    # Plot the blend radii as circles around each waypoint.
+    blend_patches = matplotlib.collections.PatchCollection(
+        [matplotlib.patches.Circle((q[0], q[1]), args.blend_radius) for q in path])
+    plt.gca().add_collection(blend_patches)
+
+# Label each waypoint
+for point_i in range(len(path)):
+    point = path[point_i]
+    plt.text(point[0], point[1], 'waypoint_{}'.format(point_i))
 
 plt.gca().set_aspect('equal')
 

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,4 +1,4 @@
-from parameterize_path import parameterize_path
+from parameterize_path import parameterize_path, blend_parameterized_path
 from piecewise_function import PiecewiseFunction
 import seven_segment_type3
 import seven_segment_type4

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,4 +1,5 @@
-from .parameterize_path import parameterize_path, blend_parameterized_path
+from .parameterize_path import (parameterize_path, blend_parameterized_path, blend_ratio, corrected_blend_ratio,
+                                create_blended_segment)
 from piecewise_function import PiecewiseFunction
 import seven_segment_type3
 import seven_segment_type4

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,5 +1,4 @@
-from .parameterize_path import (parameterize_path, blend_parameterized_path, blend_ratio, corrected_blend_ratio,
-                                create_blended_segment)
+from .parameterize_path import parameterize_path, parameterize_path_with_blends
 from piecewise_function import PiecewiseFunction
 import seven_segment_type3
 import seven_segment_type4

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -1,4 +1,4 @@
-from parameterize_path import parameterize_path, blend_parameterized_path
+from .parameterize_path import parameterize_path, blend_parameterized_path
 from piecewise_function import PiecewiseFunction
 import seven_segment_type3
 import seven_segment_type4

--- a/traj/src/traj/parameterize_path.py
+++ b/traj/src/traj/parameterize_path.py
@@ -5,9 +5,9 @@ from sympy import Float, Matrix, Piecewise, Symbol, sin, cos
 
 from piecewise_function import PiecewiseFunction
 
-
 # Values smaller than this are considered to be zero to avoid numerical problems.
 PRECISION = 1e-6
+
 
 def create_arc_segment(q_blend_start, q_unblended_waypoint, q_blend_end, blend_radius, s):
     # Make sure all arguments are simple numpy arrays (not sympy matrices).
@@ -47,10 +47,7 @@ def create_arc_segment(q_blend_start, q_unblended_waypoint, q_blend_end, blend_r
     angle = (alpha / 2.0 - s / arc_radius)
 
     return arc_length, Matrix(arc_centerpoint) + arc_radius * Matrix(-centerline_vector) * cos(
-            angle) + arc_radius * Matrix(-chord_vector) * sin(angle)
-
-    #return 2.0*blend_radius, Matrix(q_blend_start) + Matrix(chord_vector) * (
-    #        chord_length / (2.0*blend_radius)) * s
+        angle) + arc_radius * Matrix(-chord_vector) * sin(angle)
 
 
 def parameterize_path(path):
@@ -88,6 +85,7 @@ def parameterize_path(path):
         functions.append(q0 + direction * s)
     return PiecewiseFunction(boundaries, functions, s)
 
+
 def parameterize_path_with_blends(path, blend_radius):
     # We modify the path in place when we add blends. To avoid changing the path which was passed
     # in, we make a copy here.
@@ -99,9 +97,9 @@ def parameterize_path_with_blends(path, blend_radius):
     # q0 and q1 are successive joint space positions in the path. "boundaries" are the values of the
     # independent variable (often time) at which we switch from one function to the next in our
     # piecewise representation.
-    for point_i in range(len(path)-1):
+    for point_i in range(len(path) - 1):
         q0 = Matrix(path[point_i])
-        q1 = Matrix(path[point_i+1])
+        q1 = Matrix(path[point_i + 1])
         s0 = boundaries[-1]
         length = (q1 - q0).norm()
         s1 = s0 + length
@@ -119,20 +117,18 @@ def parameterize_path_with_blends(path, blend_radius):
 
             q_blend_start = functions[-1].subs(s, segment_length)
 
-            q2 = Matrix(path[point_i+2])
+            q2 = Matrix(path[point_i + 2])
             length_next = (q2 - q1).norm()
             direction_next = (q2 - q1) / length_next
             q_blend_end = q1 + direction_next * blend_radius
 
             arc_length, arc_function = create_arc_segment(q_blend_start, q1, q_blend_end,
-                    blend_radius, s)
+                                                          blend_radius, s)
 
             boundaries.append(boundaries[-1] + arc_length)
             functions.append(arc_function)
 
             path[point_i + 1] = np.array(functions[-1].subs(s, arc_length)).astype(
-                    np.float64).flatten()
+                np.float64).flatten()
 
     return PiecewiseFunction(boundaries, functions, s)
-
-

--- a/traj/src/traj/plot.py
+++ b/traj/src/traj/plot.py
@@ -63,3 +63,4 @@ def plot_2d_path(axes, piecewise_function, npoints, linewidth=1.0, label='path p
     axes.set_xlabel('Joint 1')
     axes.set_ylabel('Joint 2')
     axes.set_ylabel('Joint 2')
+

--- a/traj/src/traj/plot.py
+++ b/traj/src/traj/plot.py
@@ -53,12 +53,12 @@ def plot_trajectory(figure, position, velocity, acceleration, jerk, n_points=300
 """
 Plot the positions for a 2 dimensional path on the provided matplotlib axes.
 """
-def plot_2d_path(axes, piecewise_function, npoints, label='path points'):
+def plot_2d_path(axes, piecewise_function, npoints, linewidth=1.0, label='path points'):
     """
     Plot a 2d path that is represented as a piecewise function of a single variable.
     """
     S, path_points = piecewise_function.sample(npoints)
-    axes.plot(path_points[:,0], path_points[:,1], 'r.-', label=label)
+    axes.plot(path_points[:,0], path_points[:,1], 'r.-', linewidth=linewidth, label=label)
     axes.set_title('Joint space path')
     axes.set_xlabel('Joint 1')
     axes.set_ylabel('Joint 2')

--- a/traj/test/test_parameterize_path.py
+++ b/traj/test/test_parameterize_path.py
@@ -1,0 +1,23 @@
+import nose
+import numpy as np
+from sympy import diff, Symbol
+
+import traj
+
+
+def test_blend_function():
+    s = Symbol('s')
+    # To create a blend that connects to both the previous and next segment, the value must be 0.0 for s=0.0,
+    # 1.0 for s=1.0. For the connection between the blended portion and the neighboring segments to be smooth, the
+    # derivative of the blend ratio must be 0 at both ends.
+    blend_ratio_function = traj.blend_ratio(s)
+    assert blend_ratio_function.subs(s, 0.0) == 0.0
+    assert diff(blend_ratio_function, s).subs(s, 0.0) == 0.0
+    assert blend_ratio_function.subs(s, 1.0) == 1.0
+    assert diff(blend_ratio_function, s).subs(s, 1.0) == 0.0
+
+def test_corrected_blend_function():
+    s = Symbol('s')
+    corrected_blend_ratio_function = traj.corrected_blend_ratio(s, 0.0, 10.9)
+    assert np.isclose(float(corrected_blend_ratio_function.subs(s, 0.0)), 0.0, 1e-7)
+    assert np.isclose(float(corrected_blend_ratio_function.subs(s, 10.9)), 1.0, 1e-7)

--- a/traj/test/test_parameterize_path.py
+++ b/traj/test/test_parameterize_path.py
@@ -1,23 +1,6 @@
 import nose
 import numpy as np
-from sympy import diff, Symbol
 
 import traj
 
 
-def test_blend_function():
-    s = Symbol('s')
-    # To create a blend that connects to both the previous and next segment, the value must be 0.0 for s=0.0,
-    # 1.0 for s=1.0. For the connection between the blended portion and the neighboring segments to be smooth, the
-    # derivative of the blend ratio must be 0 at both ends.
-    blend_ratio_function = traj.blend_ratio(s)
-    assert blend_ratio_function.subs(s, 0.0) == 0.0
-    assert diff(blend_ratio_function, s).subs(s, 0.0) == 0.0
-    assert blend_ratio_function.subs(s, 1.0) == 1.0
-    assert diff(blend_ratio_function, s).subs(s, 1.0) == 0.0
-
-def test_corrected_blend_function():
-    s = Symbol('s')
-    corrected_blend_ratio_function = traj.corrected_blend_ratio(s, 0.0, 10.9)
-    assert np.isclose(float(corrected_blend_ratio_function.subs(s, 0.0)), 0.0, 1e-7)
-    assert np.isclose(float(corrected_blend_ratio_function.subs(s, 10.9)), 1.0, 1e-7)


### PR DESCRIPTION
Polynomial based blending of the geometrical path didn't create the shapes we wanted: https://github.com/iron-ox/trajectory_smoothing/pull/11 . In the original Pilz paper, they applied the blending to time parameterized trajectory. I don't think we can use the same approach, because the third derivative of the blending ratio polynomial has large values.

I think that using arcs to geometrically blend the linear segments of the path is a better approach. An arc has constant curvature, and so should be close to optimal (max velocity and acceleartion are limited by the max curvature). The math is a bit dense to compute the curve that matches the segment points and directions. Before we merge this PR, I'll add a diagram showing what the variables mean.

Here's the output of parameterize_path_example, which now uses the blending:
![Screenshot from 2020-03-01 20-39-44](https://user-images.githubusercontent.com/1538056/75646275-f0060000-5bfd-11ea-8dc8-e20967626f55.png)

We do still need to decide how to handle adjacent waypoints that are closer than 2*blend_radius (the blending regions would overlap). The easiest solution would be to adaptively reduce the blend_radius for those waypoints. This would work but could result in higher curvature blends.

/cc @mahmoud-a-ali @bhomberg @gavanderhoorn