### PR TITLE
trajectory synchronization in time domain 

### DIFF
--- a/traj/scripts/synchronized_traj_example.py
+++ b/traj/scripts/synchronized_traj_example.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+'''
+example to check the joint motion synchronization algorithm [full trajectory] 
+'''
+import numpy as np
+import math
+import traj
+from matplotlib import pyplot as plt
+import rospy
+
+rospy.init_node('traj_synchronization', log_level=rospy.DEBUG)
+# limits, option_1: same limits that Jon used in first demo file
+abs_max_pos = np.deg2rad(np.array([ 185.0,    60.0,  132.0,  360.0,  125.0,   360.0]))
+abs_max_vel = np.deg2rad(np.array([ 150.0,   150.0,  200.0,  300.0,  300.0,   600.0]))
+abs_max_acc = np.deg2rad(np.array([ 500.0,   500.0,  700.0, 1100.0, 1100.0,  2500.0]))
+abs_max_jrk = np.deg2rad(np.array([ 4500.0, 4500.0, 5000.0, 8000.0, 8000.0, 16000.0]))
+
+# limits, option_2: r-2000ic/165f that Gijs send
+abs_max_pos = np.deg2rad(np.array([ 185.0, 60.0, 132.0, 360.0, 125.0, 360.0]))
+abs_max_vel = np.deg2rad(np.array([ 1.300e+02, 1.150e+02, 1.250e+02, 1.800e+02, 1.800e+02,  2.600e+02 ]))
+abs_max_acc = np.deg2rad(np.array([ 2.532467e+02, 2.240260e+02, 2.435065e+02, 3.506494e+02, 3.506494e+02, 5.064935e+02]))
+abs_max_jrk = np.deg2rad(np.array([ 9.866757e+02, 8.728286e+02, 9.487267e+02, 1.366166e+03, 1.366166e+03,  1.973351e+03]))
+
+#limits, option_3: M-20iB/25C that Gijs send
+abs_max_pos = np.array([ 2.967060,  2.443461,  5.215218,  3.490659,  2.530727,  4.712389 ])
+abs_min_pos = np.array([-2.967060, -1.745329, -2.600541, -3.490659, -2.530727, -4.712389 ])
+# for now we consider even max/min position limits 
+pos_limits = [min(a, abs(b)) for a,b in zip(abs_max_pos, abs_min_pos)] 
+abs_max_pos = np.array(pos_limits)
+abs_max_vel = np.array([ 3.577925,   3.577925,   4.537856,  7.243116,    7.243116,   15.358897])
+abs_max_acc = np.array([ 12.423351,  12.423351,  15.756445,  25.149706,  25.149706,  53.329513])
+abs_max_jrk = np.array([ 86.273266,  86.273266,  109.419752, 174.650735, 174.650735, 370.343857])
+
+# print the limits
+rospy.logdebug("> abs_max_pos:{}".format(abs_max_pos))
+rospy.logdebug("> abs_max_vel:{}".format(abs_max_vel))
+rospy.logdebug("> abs_max_acc:{}".format(abs_max_acc))
+rospy.logdebug("> abs_max_jrk:{}".format(abs_max_jrk))
+
+# path_option_1: Jon's path [the one Jon used for the first demo with zeros velocities]
+path =[]
+path.append([ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+path.append([ 1.5, 0.7, 0.3, 0.0, 0.0, 0.0])
+path.append([ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+path.append([-1.5, 0.7, 0.3, 0.0, 0.0, 0.0])
+path.append([ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+#there is only one point that is not changing the motion direction 
+estimated_vel = [ ]
+estimated_vel.append([  0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+estimated_vel.append([  0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+estimated_vel.append([ -2.7, 0.0, 0.0, 0.0, 0.0, 0.0])
+estimated_vel.append([  0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+estimated_vel.append([  0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+#path_option_1: random traj & random velocities
+path =[]
+path.append([ 0.0,   0.0,   0.0,   0.0,   0.0, 0.0])
+path.append([ 1.0,   0.4,   0.5,   0.5,   0.0, 0.0])
+path.append([ 1.5,   0.2,   0.7,   0.8,   0.0, 0.0])
+path.append([ 2.0,   0.0,   0.9,   1.2,   0.0, 0.0])
+path.append([ 0.5,   -0.6,  0.4,   -.5,   0.0, 0.0])
+path.append([ 0.0,   -0.8,  0.0,   -1.0,  0.0, 0.0])
+estimated_vel = [ ]
+estimated_vel.append([ 0.0,   0.0,   0.0,    0.0,   0.0,   0.0])
+estimated_vel.append([ 1.4,   0.0,   0.5,    0.7,   0.0,   0.0])
+estimated_vel.append([ 1.4,  -0.6,   0.5,    0.7,   0.0,   0.0])
+estimated_vel.append([ 0.0,   0.0,   0.0,    0.0,   0.0,   0.0])
+estimated_vel.append([-0.9,  -0.3,  -0.6,   -0.9,   0.0,   0.0])
+estimated_vel.append([ 0.0,   0.0,   0.0,    0.0,   0.0,   0.0])
+
+n_jts = len(path[0])
+n_wpts = len(path)
+n_segs = n_wpts - 1
+min_sync_time_seg = [ ]
+phases_dur_seg_jt = [ ]
+phases_jrk_seg_jt = [ ]
+
+# variables for sampling times and plotting
+frq = 125.0
+t_start = 0.0
+abs_t = t_start
+traj_pos = [ [] for jt in range(n_jts)]
+traj_vel = [ [] for jt in range(n_jts)]
+traj_acc = [ [] for jt in range(n_jts)]
+traj_jrk = [ [] for jt in range(n_jts)]
+traj_time = [ ]
+
+waypt_times = [ ]
+waypt_times.append(t_start)
+for seg in range(n_segs):
+	rospy.logdebug("\n\n>> seg_numer: {}".format(seg))
+	min_sync_time, phase_dur_jt, phase_jrk_jt = traj.segment_synchronization(
+														path[seg], path[seg+1], estimated_vel[seg], estimated_vel[seg+1],
+		                        						abs_max_pos, abs_max_vel, abs_max_acc, abs_max_jrk)
+	waypt_times.append(waypt_times[-1] + min_sync_time)
+	while abs_t <= waypt_times[-1]:
+		for jt in range(n_jts):
+			p_start = path[seg][jt]
+			v_start = estimated_vel[seg][jt]
+			phases_dur = phase_dur_jt[jt]
+			phases_jrk = phase_jrk_jt[jt]
+			pos, vel, acc, jrk = traj.sample_segment(abs_t, waypt_times[-2], p_start, v_start, phases_jrk, phases_dur)
+			traj_pos[jt].append(pos)
+			traj_vel[jt].append(vel)
+			traj_acc[jt].append(acc)
+			traj_jrk[jt].append(jrk)	
+		traj_time.append(abs_t)
+		abs_t = abs_t + 1/frq
+
+# plot pos, vel, acc, jrk. plot waypoints and estimated velocity as well to check if there is any difference 
+fig, axes = plt.subplots(4, sharex=True)
+for jt in range(0, n_jts): 
+    axes[0].plot(traj_time, traj_pos[jt])
+    axes[1].plot(traj_time, traj_vel[jt])
+    axes[2].plot(traj_time, traj_acc[jt])
+    axes[3].plot(traj_time, traj_jrk[jt])
+    axes[0].plot(waypt_times, [path[wpt][jt] for wpt in range(n_wpts)], '*')
+    axes[1].plot(waypt_times, [estimated_vel[wpt][jt] for wpt in range(n_wpts)], '*')
+axes[0].grid()
+axes[1].grid()
+axes[2].grid()
+axes[3].grid()
+axes[0].set_ylabel('position')
+axes[1].set_ylabel('velocity')
+axes[2].set_ylabel('acceleration')
+axes[3].set_ylabel('jerk')
+axes[3].set_xlabel('Time')
+plt.legend()
+plt.show()
+
+# store outputs [pos, vel, acc, jrk] in csv file
+# traj_pos = list(map(list, zip(*traj_pos)))
+# traj_vel = list(map(list, zip(*traj_vel)))
+# traj_acc = list(map(list, zip(*traj_acc)))
+# traj_jrk = list(map(list, zip(*traj_jrk)))
+# import csv
+# with open("sampled_traj_time_pos_vel_acc_jrk_125.csv", "wb") as csv_file:
+#         writer = csv.writer(csv_file, delimiter=',')
+#         for pt in range(len(traj_time)):
+#             writer.writerow([traj_time[pt]] + traj_pos[pt] + traj_vel[pt] + traj_acc[pt] + traj_jrk[pt])
+
+# with open("sampled_traj_time_positions_125.csv", "wb") as csv_file:
+#         writer = csv.writer(csv_file, delimiter=',')
+#         for pt in range(len(traj_time)):
+#             writer.writerow([traj_time[pt]] + traj_pos[pt])

--- a/traj/src/traj/__init__.py
+++ b/traj/src/traj/__init__.py
@@ -28,3 +28,4 @@ from param_max_reachable_vel import reachable_vel_at_each_waypoint_multi_dof_pat
 
 from synchronize_joint_motion import synchronize_joint_motion
 from synchronize_joint_motion import motion_direction
+from synchronize_joint_motion import segment_synchronization

--- a/traj/src/traj/synchronize_joint_motion.py
+++ b/traj/src/traj/synchronize_joint_motion.py
@@ -7,7 +7,7 @@ import rospy
 
 def synchronize_joint_motion(t_syn, pos_diff, v_start, v_end, abs_max_pos, abs_max_vel, abs_max_acc, abs_max_jrk):
 	'''
-	this function selects a motion profile for  a general trajectory segment considering the total motion time of the segment is "t_syn"
+	this function selects a motion profile for a general trajectory segment considering the total motion time of the segment is "t_syn"
 	it returns the jerk_value && duration associated with each phase of the segment
 	it raise an error if:
 		1. if the given time "t_syn" is less than the minimum time caclulated using the maximum jerk 
@@ -98,3 +98,62 @@ def motion_direction( v_start, v_end, pos_diff):
 	else:
 		raise ValueError("identify_motion_direction: motion is not feasible")
 		return 0 
+
+
+def segment_synchronization(pos_start, pos_end, vel_start, vel_end, 
+	                        abs_max_pos, abs_max_vel, abs_max_acc, abs_max_jrk):
+	'''
+	A high level segment synchronization function based on the "synchronize_joint_motion" function.
+	it is used to synchronize n-dof segment!
+	this function is based on the same idea of the paper entitled : 
+	Online Trajectory Generation: Basic Concepts for Instantaneous Reactions to Unforeseen Events[1], 
+	section V,  synchronization steps 1,2,3
+	[1] https://www-cs.stanford.edu/groups/manips/publications/pdfs/Kroeger_2010_TRO.pdf
+	'''
+	rospy.logdebug(">> pos_start:\n{}".format(pos_start))
+	rospy.logdebug(">> pos_end:\n{}".format(pos_end))
+	rospy.logdebug(">> vel_start:\n{}".format(vel_start))
+	rospy.logdebug(">> vel_end:\n{}".format(vel_end))
+	pos_diff = [pf-pi for pi, pf in zip(pos_start, pos_end)]
+	motion_dir = [] 
+	n_jts = len(pos_diff)
+	for jt in range(n_jts):
+		motion_dir.append(traj.motion_direction(vel_start[jt],  vel_end[jt], pos_diff[jt]))
+
+	# step 1: find the minimum time motion for each joints 
+	min_motion_time  = [ ]
+	for jt in range(n_jts):
+		# min time for each segment: phases times
+		tj_2vf, ta_2vf, t_jrk, t_acc, t_vel = traj.traj_segment_planning(0.0, abs(pos_diff[jt]), abs(vel_start[jt]), abs(vel_end[jt]),
+																		 abs_max_vel[jt], abs_max_acc[jt], abs_max_jrk[jt])
+		min_time = 2*tj_2vf + ta_2vf +  4*t_jrk + 2*t_acc + t_vel
+		min_motion_time.append(min_time) 
+
+	# step 2: find the joint that has the maximum time motion (reference joint)
+	ref_jt = min_motion_time.index(max(min_motion_time))
+	min_sync_time  = max(min_motion_time) 
+	syn_t = min_sync_time
+	rospy.logdebug(">> syn_t : {} ".format(syn_t))
+	rospy.logdebug(">> ref_jt: {} ".format(ref_jt))
+	rospy.logdebug(">> min_T : {} ".format(min_motion_time))
+
+	# step 3: calculate new jrk_sgn_dur
+	phase_dur_jt = []
+	phase_jrk_jt = []
+	for jt in range(n_jts):
+		rospy.logdebug("\n\n>> jt:{}, PD: {}, v_start:{}, v_end:{}".format(jt, pos_diff[jt], vel_start[jt], vel_end[jt]))
+		p_diff = abs(pos_diff[jt])   
+		v_start = abs(vel_start[jt])
+		v_end = abs(vel_end[jt])
+		if jt == ref_jt:
+			jrk_sign_dur = traj.calculate_jerk_sign_and_duration(0.0, p_diff, v_start, v_end, 
+								abs_max_pos[jt], abs_max_vel[jt], abs_max_acc[jt], abs_max_jrk[jt])
+		else:
+			jrk_sign_dur = synchronize_joint_motion(syn_t, p_diff, v_start, v_end, 
+								abs_max_pos[jt], abs_max_vel[jt], abs_max_acc[jt], abs_max_jrk[jt])
+		dur = [jsd[1] for jsd in jrk_sign_dur]
+		jrk = [motion_dir[jt]*jsd[0] for jsd in jrk_sign_dur]
+		phase_dur_jt.append(dur)
+		phase_jrk_jt.append(jrk)
+		rospy.logdebug(">> dur:{}".format(sum(dur)))
+	return min_sync_time, phase_dur_jt, phase_jrk_jt


### PR DESCRIPTION
expanding the previous **segment_synchronization** algorithm that handles non-zero velocities at waypoints to a general **trajectory_synchronization** [n-dof, m-segment]:
- Random trajectory:
![synchonized_motion_time_domain](https://user-images.githubusercontent.com/46086657/79995384-754bb980-84b7-11ea-9b26-40b96dd84c6e.png)

- The first trajectory that Jon used in the demo file:
![synchronized_motion_Jon_path](https://user-images.githubusercontent.com/46086657/79996197-70d3d080-84b8-11ea-8516-a4c1b0d396d7.png)

PS: these motion profile considering the limits of M-20iB/25C 